### PR TITLE
Set config on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,21 @@ Format strings for generic matches can use the following values:
 
 Contributions are welcome - feel free to open a PR, or message Pox on the
 Stormgate Discord if you want to discuss with me first.
+
+### Building
+
+Create a working directory:
+```
+mkdir shroudstone-workspace
+cd shroudstone-workspace
+```
+Download the code and setup a python virtual environment:
+```
+python -m venv .
+git clone https://github.com/acarapetis/shroudstone.git
+```
+Finally, install and run the code:
+```
+./bin/pip3 install -e shroudstone/
+./bin/shroudstone
+```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,14 @@ Format strings for generic matches can use the following values:
 Contributions are welcome - feel free to open a PR, or message Pox on the
 Stormgate Discord if you want to discuss with me first.
 
-### Building
+### Developing
+
+Assuming you have python 3.8+ and pip installed on your system, all you need to
+do to start working on shroudstone is to clone the repository and install the
+python package in *development mode*. [See
+here](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) for
+more information, or follow this recipe to get started using a virtual
+environment:
 
 Create a working directory:
 ```
@@ -175,11 +182,11 @@ cd shroudstone-workspace
 ```
 Download the code and setup a python virtual environment:
 ```
-python -m venv .
+python -m venv .venv
 git clone https://github.com/acarapetis/shroudstone.git
 ```
 Finally, install and run the code:
 ```
-./bin/pip3 install -e shroudstone/
-./bin/shroudstone
+.venv/bin/pip3 install -e shroudstone/
+.venv/bin/shroudstone
 ```

--- a/shroudstone/config.py
+++ b/shroudstone/config.py
@@ -66,7 +66,9 @@ class Config(BaseModel):
                     content["replay_name_format_1v1"] = content["replay_name_format"]
                 return Config.model_validate(content)
         else:
-            return Config()
+            config = Config()
+            config.save()
+            return config
 
     def save(self):
         with config_file.open("wt", encoding="utf-8") as f:

--- a/shroudstone/renamer.py
+++ b/shroudstone/renamer.py
@@ -76,7 +76,7 @@ def migrate():
             last_run_version_file.read_text(encoding="utf-8")
         )
     else:
-        last_run_version = version.parse("0.1.0a29")
+        last_run_version = version.parse(__version__)
     if last_run_version < version.parse("0.1.0a30"):
         logger.info(
             "Cache files are from an incompatible version of shroudstone, deleting them."

--- a/shroudstone/renamer.py
+++ b/shroudstone/renamer.py
@@ -76,7 +76,7 @@ def migrate():
             last_run_version_file.read_text(encoding="utf-8")
         )
     else:
-        last_run_version = version.parse(__version__)
+        last_run_version = version.parse("0.1.0a29")
     if last_run_version < version.parse("0.1.0a30"):
         logger.info(
             "Cache files are from an incompatible version of shroudstone, deleting them."


### PR DESCRIPTION
Right now there is an error on first run where you are unable to exit. To reproduce delete the whole shoudstone data directory and rerun shroudstone. The app will mostly start fine but the Exit button does nothing.

Error message on cli:
```
INFO     Cache files are from an incompatible version of shroudstone, deleting them.                                                                                         
INFO     Setting renaming config to use replays only - RIP stormgateworld API :(                                                                                             
INFO     Keep this console open - it will show progress information during renaming.                                                                                         
Exception in thread Thread-1 (_tray_icon_thread):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/home/rrojas/workspace/shroudstone/shroudstone/shroudstone/gui/app.py", line 123, in _tray_icon_thread
    @state.autorename.on_change
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rrojas/workspace/shroudstone/shroudstone/shroudstone/gui/app.py", line 34, in on_change
    self.trace_add("write", func)
  File "/usr/lib/python3.12/tkinter/__init__.py", line 459, in trace_add
    cbname = self._register(callback)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/tkinter/__init__.py", line 443, in _register
    self._tk.createcommand(cbname, f)
RuntimeError: main thread is not in main loop
````

Fixed by saving the config on first load and choosing the current version as the last run (since there is no last run).

Also updated the readme with build steps.