### PR TITLE
Add: CrookedCanyon to Co-op maps

### DIFF
--- a/shroudstone/replay.py
+++ b/shroudstone/replay.py
@@ -176,6 +176,7 @@ player_slot_count: Dict[str, int] = defaultdict(
         "IsleOfDread": 3,
         "RitualWoods": 3,
         "InfestedCrater": 3,
+        "CrookedCanyon": 3,
     },
 )
 


### PR DESCRIPTION
Always got to miss one

Not sure the order of operations but perhaps we could use the faction to determine if its Co-op? anything above 100 and we know its coop. This works until 3v3 comes out i think.