### PR TITLE
Added co-op faction Ryker

### DIFF
--- a/shroudstone/replay/parser.py
+++ b/shroudstone/replay/parser.py
@@ -124,6 +124,7 @@ class Faction(IntEnum):
     Celestial = 2
     Blockade = 101
     Amara = 102
+    Ryker = 103
     Maloc = 201
     Warz = 202
     Auralanna = 301


### PR DESCRIPTION
Stormgate recently added the new co-op hero Ryker as Faction ID 103. I just added it to the Faction enum to make Shroudstone work with recent co-op replays.